### PR TITLE
Two fixes to properly install pfio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools>=40.8.0", "numpy"]

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 from distutils.core import setup, Extension
 import numpy 
 
-setup(name = 'pfio', version = '1.0',  \
-   ext_modules = [Extension('pfio', ['pfio.c'],
-                  include_dirs=[numpy.get_include()]),
+setup(
+    name = 'pfio',
+    version = '1.0',
+    ext_modules = [
+        Extension('pfio', ['pfio.c'], include_dirs=[numpy.get_include()]),
     ],
+    install_requires=['numpy']
 )


### PR DESCRIPTION
1. An `install_requires` section in `setup.py` tells `setuptools` that `numpy` is required for the proper installation of the `pfio` package.
2. Since `setup.py` itself imports `numpy`, which may or may not be installed (and will mostly likely **not** be already installed in a brand new environment), a `pyproject.toml` file (a PEP specification that has been around a few years now) tells `setuptools` that `numpy` is also needed to actually *build* the `pfio` package.

With these 2 changes, anytime we say `pip install .`, `setuptools` will create an isolated environment with `numpy` and build the `pfio` package, discard the temporary environment, and install `pfio` (along with `numpy`, which it gets from the `install_requires` section).